### PR TITLE
show usage() on invalid use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
 name = "diffr"
 version = "0.1.0"
 dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ debug = true
 [dependencies]
 termcolor = "1"
 clap = "2.33.0"
+atty = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use termcolor::{
     Color::{Green, Red},
     ColorChoice, ColorSpec, StandardStream, WriteColor,
 };
+use atty::{is, Stream};
 
 const ABOUT: &str = "
 diffr adds word-level diff on top of unified diffs.
@@ -48,6 +49,10 @@ fn main() {
         .arg(Arg::with_name(FLAG_DEBUG).long("debug").hidden(true))
         .get_matches();
 
+    if is(Stream::Stdin) {
+        println!("{}", matches.usage());
+        std::process::exit(1)
+    }
     let config = AppConfig {
         debug: matches.is_present(FLAG_DEBUG),
     };


### PR DESCRIPTION
the application is designed to be run as a filter, but if called without
data in stdin will seem to "hang".

detect if stdin is attached to a tty and abort instead printing usage()
to stdout as is commonly done by other filters (ex: more, less)

Signed-off-by: Carlo Marcelo Arenas Belón <carenas@gmail.com>