### PR TITLE
README: Extend example git integration to cover interactive add etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Add the following section to your `.gitconfig` file:
     log  = path/to/diffr | less -R
     show = path/to/diffr | less -R
     diff = path/to/diffr | less -R
+[interactive]
+    diffFilter = path/to/diffr
 ```
 
 #### Display customization


### PR DESCRIPTION
The currently suggested git integration does not activate `diffr` when using interactive git commands such as the useful `git add -p` etc.

This change proposes to add `diffr` not only the `pager.*` config options, but also to `interactive.diffFilter`, so diffs are nicely formatted also in these cases.