### PR TITLE
main.rs: use White as a foreground for Red and Green

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::io::{self, BufRead};
 use std::time::SystemTime;
 use termcolor::{
     Color,
-    Color::{Green, Red},
+    Color::{Green, Red, White},
     ColorChoice, ColorSpec, StandardStream, WriteColor,
 };
 
@@ -25,9 +25,9 @@ impl Default for AppConfig {
         AppConfig {
             debug: false,
             added_face: color_spec(Some(Green), None, false),
-            refine_added_face: color_spec(None, Some(Green), true),
+            refine_added_face: color_spec(Some(White), Some(Green), true),
             removed_face: color_spec(Some(Red), None, false),
-            refine_removed_face: color_spec(None, Some(Red), true),
+            refine_removed_face: color_spec(Some(White), Some(Red), true),
         }
     }
 }


### PR DESCRIPTION
Red and Green are dark colors, so when letters are black on them, it
makes them blend a bit. Use a brighter color instead, White.

Fixes: https://github.com/mookid/diffr/issues/31
