### PR TITLE
Tokenization: skip leading whitespaces.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,3 +33,5 @@ steps:
   - template: ci/azure-runtests.yml
     parameters:
       crate_path: diffr-lib
+
+  - template: ci/azure_integration_test.yml

--- a/ci/azure_integration_test.yml
+++ b/ci/azure_integration_test.yml
@@ -6,9 +6,9 @@ steps:
 
   - script: |
       set -e
-      EXPECTED="$(git log -p | sha256sum)"
-      ACTUAL="$(git log -p | cargo run | trimcolor | sha256sum)"
-      if test "${ACTUAL}" = "${EXPECTED}"
+      git log -p >whole_log
+      cargo run <whole_log | trimcolor >whole_log_diffr
+      if git diff --no-index whole_log whole_log_diffr
       then
               exit 0
       else

--- a/ci/azure_integration_test.yml
+++ b/ci/azure_integration_test.yml
@@ -1,0 +1,19 @@
+steps:
+  - script: |
+      set -e
+      cargo install --git https://github.com/mookid/trimcolor
+    displayName: Install trimcolor
+
+  - script: |
+      set -e
+      EXPECTED="$(git log -p | sha256sum)"
+      ACTUAL="$(git log -p | cargo run | trimcolor | sha256sum)"
+      if test "${ACTUAL}" = "${EXPECTED}"
+      then
+              exit 0
+      else
+              exit 1
+      fi
+      
+    displayName: Integration test
+    condition: eq(variables['Agent.OS'], 'Linux')

--- a/diffr-lib/src/lib.rs
+++ b/diffr-lib/src/lib.rs
@@ -555,15 +555,10 @@ pub fn tokenize(src: &[u8], ofs: usize, tokens: &mut Vec<HashedSpan>) {
     let mut start_of_line = true;
     for hi in ofs..src.len() {
         let oldkind = kind;
-        let b = src[hi];
-        kind = classify_byte(b);
+        kind = classify_byte(src[hi]);
         if oldkind == TokenKind::NewLine {
             start_of_line = true;
-            if b == b' ' || b == b'+' || b == b'-' {
-                // skip the tokenization of the leading token
-                lo = hi;
-                continue;
-            }
+            continue;
         }
 
         if kind == TokenKind::Spaces && start_of_line {

--- a/diffr-lib/src/lib.rs
+++ b/diffr-lib/src/lib.rs
@@ -567,15 +567,11 @@ pub fn tokenize(src: &[u8], ofs: usize, tokens: &mut Vec<HashedSpan>) {
             continue;
         }
 
-        if kind != oldkind || kind == TokenKind::Other {
-            push(lo, hi);
-            lo = hi
-        }
-        start_of_line = false;
         if kind != oldkind || oldkind == TokenKind::Other {
             push(lo, hi);
             lo = hi
         }
+        start_of_line = false;
     }
     push(lo, src.len());
 }

--- a/diffr-lib/src/test.rs
+++ b/diffr-lib/src/test.rs
@@ -63,18 +63,8 @@ fn dummy_tokenize<'a>(data: &'a [u8]) -> Vec<HashedSpan> {
     toks
 }
 
-fn really_tokenize<'a>(data: &'a [u8]) -> Vec<HashedSpan> {
-    let mut toks = vec![];
-    tokenize(data, 0, &mut toks);
-    toks
-}
-
 fn diff_sequences_test(expected: &[(&[u8], DiffKind)], seq_a: &[u8], seq_b: &[u8]) {
     diff_sequences_test_aux(expected, seq_a, seq_b, dummy_tokenize)
-}
-
-fn diff_sequences_test_tokenized(expected: &[(&[u8], DiffKind)], seq_a: &[u8], seq_b: &[u8]) {
-    diff_sequences_test_aux(expected, seq_a, seq_b, really_tokenize)
 }
 
 fn diff_sequences_test_aux<Tok>(
@@ -553,49 +543,20 @@ fn check_split(input: &[u8], split: &LineSplit) {
 }
 
 #[test]
-fn issue15() {
-    diff_sequences_test_tokenized(
-        &[
-            (b"+      ", Added),
-            (b"-", Keep),
-            (b"    -", Removed),
-            (b"01234;\r\n", Keep),
-            (b"+      ", Added),
-            (b"-", Keep),
-            (b"    ", Removed),
-            (b"-", Keep),
-            (b"-", Removed),
-            (b"abc;\r\n", Keep),
-            (b"-    ", Removed),
-            (b"+      ", Added),
-            (b"--", Keep),
-            (b"def;\r\n", Keep),
-            (b"-    ", Removed),
-            (b"+      ", Added),
-            (b"--jkl;\r\n", Keep),
-            (b"+      ", Added),
-            (b"-", Keep),
-            (b"    ", Removed),
-            (b"-", Keep),
-            (b"-", Removed),
-            (b"poi;\r\n", Keep),
-        ],
-        b"-    -01234;\r\n-    --abc;\r\n-    --def;\r\n-    --jkl;\r\n-    --poi;\r\n",
-        b"+      -01234;\r\n+      --abc;\r\n+      --def;\r\n+      --jkl;\r\n+      --poi;\r\n",
-    )
-}
+fn tokenize_discards_leading_whitespaces() {
+    let buf = b"-    -01234;\r\n-    --abc;\r\n-    --def;\r\n-    --jkl;\r\n-    --poi;\r\n";
+    let mut tokens = vec![];
+    tokenize(buf, 0, &mut tokens);
+    let tokens_str: Vec<_> = tokens
+        .iter()
+        .map(|span| String::from_utf8_lossy(&buf[span.lo..span.hi]))
+        .collect();
 
-#[test]
-fn issue15_2() {
-    diff_sequences_test_tokenized(
-        &[
-            (b"-", Removed),
-            (b"+", Added),
-            (b"        --include \'+ */\'", Keep),
-            (b" ", Added),
-            (b"\r\n", Keep),
+    assert_eq!(
+        &vec![
+            "-", "01234", ";", "-", "-", "abc", ";", "-", "-", "def", ";", "-", "-", "jkl", ";",
+            "-", "-", "poi", ";", "\r\n"
         ],
-        b"-        --include '+ */'\r\n",
-        b"+        --include '+ */' \r\n",
+        &tokens_str,
     )
 }

--- a/diffr-lib/src/test.rs
+++ b/diffr-lib/src/test.rs
@@ -544,7 +544,7 @@ fn check_split(input: &[u8], split: &LineSplit) {
 
 #[test]
 fn tokenize_discards_leading_whitespaces() {
-    let buf = b"-    -01234;\r\n-    --abc;\r\n-    --def;\r\n-    --jkl;\r\n-    --poi;\r\n";
+    let buf = b"-    -01234;\r\n\r\n-    --abc;\r\n-    --def;\r\n-    --jkl;\r\n-    --poi;\r\n";
     let mut tokens = vec![];
     tokenize(buf, 0, &mut tokens);
     let tokens_str: Vec<_> = tokens

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ impl HunkBuffer {
                 continue;
             }
             // XXX: always highlight the leading +/- character
-            let lo = lo.max(data_lo + 1);
+            let lo = lo.max(y);
             let hi = hi.min(data_hi);
             if hi <= lo {
                 continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn try_main(config: AppConfig) -> io::Result<()> {
                     hunk_buffer.process(&mut stdout)?;
                 }
                 in_hunk = other == Some(b'@');
-                output(&buffer, &ColorSpec::default(), &mut stdout)?;
+                output(&buffer, 0, buffer.len(), &ColorSpec::default(), &mut stdout)?;
                 time_computing_diff_ms += duration_ms(&start);
             }
         }
@@ -161,7 +161,12 @@ impl HunkBuffer {
         Stream: WriteColor,
         Positions: Iterator<Item = (usize, usize)>,
     {
-        let mut y = data_lo;
+        let mut y = data_lo + 1;
+        // XXX: skip leading token and leading spaces
+        while y < data_hi && data[y].is_ascii_whitespace() {
+            y += 1
+        }
+        output(data, data_lo, y, &no_highlight, out)?;
         let mut nshared = 0;
         for (lo, hi) in shared {
             if hi <= data_lo {
@@ -174,13 +179,11 @@ impl HunkBuffer {
             if hi <= lo {
                 continue;
             }
-            output(&data[y..lo], &highlight, out)?;
-            output(&data[lo..hi], &no_highlight, out)?;
+            output(data, y, lo, &highlight, out)?;
+            output(data, lo, hi, &no_highlight, out)?;
             y = hi;
         }
-        if y < data_hi {
-            output(&data[y..data_hi], &highlight, out)?;
-        }
+        output(data, y, data_hi, &highlight, out)?;
         Ok(nshared)
     }
 
@@ -239,7 +242,7 @@ impl HunkBuffer {
                         out,
                     )?;
                 }
-                _ => output(&data[line_start..line_end], &ColorSpec::default(), out)?,
+                _ => output(data, line_start, line_end, &ColorSpec::default(), out)?,
             }
         }
         lines.clear();
@@ -257,8 +260,7 @@ impl HunkBuffer {
     }
 
     fn push_aux(&mut self, line: &[u8], added: bool) {
-        // XXX: don't tokenize the leading +/- character
-        let ofs = self.lines.len() + 1;
+        let ofs = self.lines.len();
         add_raw_line(&mut self.lines, line);
         diffr_lib::tokenize(
             &self.lines.data(),
@@ -283,13 +285,21 @@ fn add_raw_line(dst: &mut LineSplit, line: &[u8]) {
     }
 }
 
-fn output<Stream>(buf: &[u8], colorspec: &ColorSpec, out: &mut Stream) -> io::Result<()>
+fn output<Stream>(
+    buf: &[u8],
+    from: usize,
+    to: usize,
+    colorspec: &ColorSpec,
+    out: &mut Stream,
+) -> io::Result<()>
 where
     Stream: WriteColor,
 {
-    if buf.is_empty() {
+    let to = to.min(buf.len());
+    if from >= to {
         return Ok(());
     }
+    let buf = &buf[from..to];
     let ends_with_newline = buf.last().cloned() == Some(b'\n');
     let buf = if ends_with_newline {
         &buf[..buf.len() - 1]


### PR DESCRIPTION
This change improves the presentation; spaces following the leading
'+', '-' or ' ' in chunks is never colorized.

* diffr-lib (TokenKind::NewLine): new case.
(tokenize, classify_byte): handle specifically spaces following the first character.

* diffr (paint_line): skip spaces a second time for coloring.


Fix #26 
Fix #19
Unfortunately the info at that point does not allow to do the
processing only once.