### PR TITLE
Line numbers

### DIFF
--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -283,7 +283,7 @@ a blue background, written with a bold font.",
         .arg(
             Arg::with_name(FLAG_LINE_NUMBERS)
                 .long(FLAG_LINE_NUMBERS)
-                .help("Display line numbers.")
+                .help("Display line numbers."),
         )
         .get_matches()
 }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -18,6 +18,7 @@ diffr reads from standard input and write to standard output.
 
 pub const FLAG_DEBUG: &str = "--debug";
 pub const FLAG_COLOR: &str = "--colors";
+pub const FLAG_LINE_NUMBERS: &str = "--line-numbers";
 
 #[derive(Debug, Clone, Copy)]
 pub enum FaceName {
@@ -278,6 +279,11 @@ For example, the color_spec
 sets the color of unique added segments with
 a blue background, written with a bold font.",
                 ),
+        )
+        .arg(
+            Arg::with_name(FLAG_LINE_NUMBERS)
+                .long(FLAG_LINE_NUMBERS)
+                .help("Display line numbers.")
         )
         .get_matches()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -335,7 +335,7 @@ impl HunkBuffer {
         //     .unwrap_or_default();
         // let mut current_line_plus;
         // let mut current_line_minus;
-        let (mut current_line_plus, mut current_line_minus, /* mut */ margin) =
+        let (mut current_line_minus, mut current_line_plus, /* mut */ margin) =
             match line_number_info {
                 Some(lni) => (
                     lni.minus_range.0,
@@ -390,7 +390,6 @@ impl HunkBuffer {
                             &mut shared_removed,
                         )
                     };
-                    *lino += 1;
                     if is_plus {
                         write!(out, "{:w$}", ' ', w = half_margin)?;
                         write!(out, "{}", MARGIN_SEP)?;
@@ -400,6 +399,7 @@ impl HunkBuffer {
                         write!(out, "{}", MARGIN_SEP)?;
                         write!(out, "{:w$}", ' ', w = half_margin)?;
                     };
+                    *lino += 1;
 
                     Self::paint_line(
                         toks.data(),
@@ -411,8 +411,6 @@ impl HunkBuffer {
                     )?;
                 }
                 _ => {
-                    current_line_minus += 1;
-                    current_line_plus += 1;
                     if current_line_minus != current_line_plus {
                         write!(out, "{:w$}", current_line_minus, w = half_margin)?;
                     } else {
@@ -420,6 +418,8 @@ impl HunkBuffer {
                     }
                     write!(out, "{}", MARGIN_SEP)?;
                     write!(out, "{:w$}", current_line_plus, w = half_margin)?;
+                    current_line_minus += 1;
+                    current_line_plus += 1;
                     output(data, line_start, line_end, &ColorSpec::default(), out)?
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use atty::{is, Stream};
 
-use std::cmp;
 use std::fmt::{Debug, Display, Error as FmtErr, Formatter};
 use std::io::{self, BufRead};
 use std::iter::Peekable;
@@ -97,7 +96,6 @@ fn try_main(config: AppConfig) -> io::Result<()> {
     let mut hunk_buffer = HunkBuffer::new(config);
     let mut stdin = stdin.lock();
     let mut stdout = stdout.lock();
-    // TODO combine with hunk_buffer.line_number_info
     let mut in_hunk = false;
 
     // process hunks
@@ -333,7 +331,7 @@ impl HunkBuffer {
             Some(lni) => (
                 lni.minus_range.0,
                 lni.plus_range.0,
-                &mut margin[..cmp::max(MIN_MARGIN, lni.width())],
+                &mut margin[..lni.width().max(MIN_MARGIN)],
             ),
             None => Default::default(),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,15 +395,17 @@ impl HunkBuffer {
                     };
 
                     if config.line_numbers {
+                        out.set_color(nohighlight)?;
                         if is_plus {
                             write!(out, "{:w$}", ' ', w = half_margin)?;
                             write!(out, "{}", MARGIN_SEP)?;
-                            write!(out, "{:w$}", lino, w = half_margin)?;
+                            write!(out, "{:w$} ", lino, w = half_margin)?;
                         } else {
                             write!(out, "{:w$}", lino, w = half_margin)?;
                             write!(out, "{}", MARGIN_SEP)?;
-                            write!(out, "{:w$}", ' ', w = half_margin)?;
+                            write!(out, "{:w$} ", ' ', w = half_margin)?;
                         };
+                        out.reset()?;
                     }
                     *lino += 1;
 
@@ -424,7 +426,7 @@ impl HunkBuffer {
                             write!(out, "{:w$}", ' ', w = half_margin)?;
                         }
                         write!(out, "{}", MARGIN_SEP)?;
-                        write!(out, "{:w$}", current_line_plus, w = half_margin)?;
+                        write!(out, "{:w$} ", current_line_plus, w = half_margin)?;
                     }
                     current_line_minus += 1;
                     current_line_plus += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -560,7 +560,7 @@ struct HunkHeader {
     plus_range: (usize, usize),
 }
 
-const WIDTH: [usize; 21] = [
+const WIDTH: [usize; 20] = [
     0,
     9,
     99,
@@ -581,11 +581,10 @@ const WIDTH: [usize; 21] = [
     99999999999999999,
     999999999999999999,
     9999999999999999999,
-    usize::max_value(),
 ];
 
 fn width1(x: usize) -> usize {
-    let result = WIDTH[..WIDTH.len() - 1].binary_search(&x);
+    let result = WIDTH.binary_search(&x);
     match result {
         Ok(i) | Err(i) => i,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ fn try_main(config: AppConfig) -> io::Result<()> {
     let stdin = io::stdin();
     let stdout = StandardStream::stdout(ColorChoice::Always);
     let mut buffer = vec![];
-    let mut hunk_buffer = HunkBuffer::new(config);
+    let mut hunk_buffer = HunkBuffer::new(&config);
     let mut stdin = stdin.lock();
     let mut stdout = stdout.lock();
     let mut in_hunk = false;
@@ -114,7 +114,7 @@ fn try_main(config: AppConfig) -> io::Result<()> {
                     hunk_buffer.process_with_stats(&mut stdout)?;
                 }
                 in_hunk = other == Some(b'@');
-                if in_hunk {
+                if config.line_numbers && in_hunk {
                     hunk_buffer.line_number_info = parse_line_number(&buffer);
                 }
                 output(&buffer, 0, buffer.len(), &ColorSpec::default(), &mut stdout)?;
@@ -214,14 +214,14 @@ impl ExecStats {
     }
 }
 
-struct HunkBuffer {
+struct HunkBuffer<'a> {
     v: Vec<isize>,
     diff_buffer: Vec<Snake>,
     added_tokens: Vec<HashedSpan>,
     removed_tokens: Vec<HashedSpan>,
     line_number_info: Option<HunkHeader>,
     lines: LineSplit,
-    config: AppConfig,
+    config: &'a AppConfig,
     stats: ExecStats,
 }
 
@@ -241,8 +241,8 @@ const MIN_MARGIN: usize = 7;
 const MAX_MARGIN: usize = 41;
 const MARGIN_SEP: char = ':';
 
-impl HunkBuffer {
-    fn new(config: AppConfig) -> Self {
+impl<'a> HunkBuffer<'a> {
+    fn new(config: &'a AppConfig) -> Self {
         let debug = config.debug;
         HunkBuffer {
             v: vec![],

--- a/src/main.rs
+++ b/src/main.rs
@@ -699,7 +699,7 @@ impl<'a> LineNumberParser<'a> {
     fn parse_pair(&mut self) -> Option<(usize, usize)> {
         let p0 = self.parse_usize()?;
         if self.expect(b',').is_none() {
-            return Some((0, p0));
+            return Some((p0, 1));
         }
         let p1 = self.parse_usize()?;
         Some((p0, p1))

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,9 +235,6 @@ fn shared_spans(added_tokens: &Tokenization, diff_buffer: &Vec<Snake>) -> Vec<Ha
     shared_spans
 }
 
-// Assuming most files are less than 1000 lines,
-// pad for two 3 digit numbers plus the separator
-const MIN_MARGIN: usize = 7;
 const MAX_MARGIN: usize = 41;
 const MARGIN_SEP: char = ':';
 
@@ -331,7 +328,7 @@ impl<'a> HunkBuffer<'a> {
             Some(lni) => (
                 lni.minus_range.0,
                 lni.plus_range.0,
-                &mut margin[..lni.width().max(MIN_MARGIN)],
+                &mut margin[..lni.width()],
             ),
             None => Default::default(),
         };
@@ -384,9 +381,9 @@ impl<'a> HunkBuffer<'a> {
                     if config.line_numbers {
                         out.set_color(nohighlight)?;
                         if is_plus {
-                            write!(out, "{:w$}{}{:w$} ", ' ', MARGIN_SEP, lino, w = half_margin)?;
+                            write!(out, "{:w$}{}{:w$}", ' ', MARGIN_SEP, lino, w = half_margin)?;
                         } else {
-                            write!(out, "{:w$}{}{:w$} ", lino, MARGIN_SEP, ' ', w = half_margin)?;
+                            write!(out, "{:w$}{}{:w$}", lino, MARGIN_SEP, ' ', w = half_margin)?;
                         };
                         out.reset()?;
                     }
@@ -409,7 +406,7 @@ impl<'a> HunkBuffer<'a> {
                             write!(out, "{:w$}", ' ', w = half_margin)?;
                         }
                         write!(out, "{}", MARGIN_SEP)?;
-                        write!(out, "{:w$} ", current_line_plus, w = half_margin)?;
+                        write!(out, "{:w$}", current_line_plus, w = half_margin)?;
                     }
                     current_line_minus += 1;
                     current_line_plus += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use atty::{is, Stream};
 
+use std::cmp;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::{Error as FmtErr, Formatter};
@@ -239,6 +240,9 @@ fn shared_spans(added_tokens: &Tokenization, diff_buffer: &Vec<Snake>) -> Vec<Ha
 }
 
 // 2 * width1(usize::max_value()) + 1
+// Assuming most files are less than 1000 lines,
+// pad for two 3 digit numbers plus the separator
+const MIN_MARGIN: usize = 7;
 const MAX_MARGIN: usize = 41;
 // const MARGIN_SEP: u8 = b':';
 const MARGIN_SEP: char = ':';
@@ -343,7 +347,7 @@ impl HunkBuffer {
                 Some(lni) => (
                     lni.minus_range.0,
                     lni.plus_range.0,
-                    &mut margin[..lni.width()],
+                    &mut margin[..cmp::max(MIN_MARGIN, lni.width())],
                 ),
                 None => Default::default(),
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,8 @@
 use atty::{is, Stream};
+
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::{Error as FmtErr, Formatter};
 use std::io::{self, BufRead};
 use std::iter::Peekable;
 use std::time::SystemTime;
@@ -91,6 +95,7 @@ fn try_main(config: AppConfig) -> io::Result<()> {
     let mut hunk_buffer = HunkBuffer::new(config);
     let mut stdin = stdin.lock();
     let mut stdout = stdout.lock();
+    // TODO combine with hunk_buffer.line_number_info
     let mut in_hunk = false;
 
     // process hunks
@@ -109,6 +114,9 @@ fn try_main(config: AppConfig) -> io::Result<()> {
                     hunk_buffer.process_with_stats(&mut stdout)?;
                 }
                 in_hunk = other == Some(b'@');
+                if in_hunk {
+                    hunk_buffer.line_number_info = dbg!(parse_line_number(&buffer));
+                }
                 output(&buffer, 0, buffer.len(), &ColorSpec::default(), &mut stdout)?;
             }
         }
@@ -211,6 +219,7 @@ struct HunkBuffer {
     diff_buffer: Vec<Snake>,
     added_tokens: Vec<HashedSpan>,
     removed_tokens: Vec<HashedSpan>,
+    line_number_info: Option<HunkHeader>,
     lines: LineSplit,
     config: AppConfig,
     stats: ExecStats,
@@ -234,6 +243,7 @@ impl HunkBuffer {
             diff_buffer: vec![],
             added_tokens: vec![],
             removed_tokens: vec![],
+            line_number_info: None,
             lines: Default::default(),
             config,
             stats: ExecStats::new(debug),
@@ -305,6 +315,7 @@ impl HunkBuffer {
             diff_buffer,
             added_tokens,
             removed_tokens,
+            line_number_info: _,
             lines,
             config,
             stats,
@@ -495,6 +506,186 @@ fn skip_token(buf: &[u8]) -> usize {
             len
         }
     }
+}
+
+#[derive(Default, PartialEq, Eq)]
+struct HunkHeader {
+    // range are (ofs,len) for the interval [ofs, ofs + len)
+    minus_range: (usize, usize),
+    plus_range: (usize, usize),
+}
+
+const WIDTH: [usize; 21] = [
+    0,
+    9,
+    99,
+    999,
+    9999,
+    99999,
+    999999,
+    9999999,
+    99999999,
+    999999999,
+    9999999999,
+    99999999999,
+    999999999999,
+    9999999999999,
+    99999999999999,
+    999999999999999,
+    9999999999999999,
+    99999999999999999,
+    999999999999999999,
+    9999999999999999999,
+    usize::max_value(),
+];
+
+fn width1(x: usize) -> usize {
+    let result = WIDTH[..WIDTH.len() - 1].binary_search(&x);
+    match result {
+        Ok(i) | Err(i) => i,
+    }
+}
+
+impl HunkHeader {
+    fn new(mr_lo: usize, mr_len: usize, pr_lo: usize, pr_len: usize) -> Self {
+        HunkHeader {
+            minus_range: (mr_lo, mr_len),
+            plus_range: (pr_lo, pr_len),
+        }
+    }
+
+    fn width(&self) -> usize {
+        width1(self.minus_range.0 + self.minus_range.1)
+            + 1
+            + width1(self.plus_range.0 + self.plus_range.1)
+    }
+}
+
+impl Debug for HunkHeader {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtErr> {
+        f.write_fmt(format_args!(
+            "-{},{} +{},{}",
+            self.minus_range.0, self.minus_range.1, self.plus_range.0, self.plus_range.1,
+        ))
+    }
+}
+
+impl Display for HunkHeader {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtErr> {
+        Debug::fmt(&self, f)
+    }
+}
+
+struct LineNumberParser<'a> {
+    buf: &'a [u8],
+    i: usize,
+}
+
+impl<'a> LineNumberParser<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        LineNumberParser { buf, i: 0 }
+    }
+
+    fn skip_escape_code(&mut self) {
+        if self.i < self.buf.len() {
+            let to_skip = skip_all_escape_code(&self.buf[self.i..]);
+            self.i += to_skip;
+        }
+    }
+
+    fn looking_at<M>(&mut self, matcher: M) -> bool
+    where
+        M: Fn(u8) -> bool,
+    {
+        self.skip_escape_code();
+        self.i < self.buf.len() && matcher(self.buf[self.i])
+    }
+
+    fn read_digit(&mut self) -> Option<usize> {
+        if self.looking_at(|x| x.is_ascii_digit()) {
+            let cur = self.buf[self.i];
+            self.i += 1;
+            Some((cur - b'0') as usize)
+        } else {
+            None
+        }
+    }
+
+    fn skip_whitespaces(&mut self) {
+        while self.looking_at(|x| x.is_ascii_whitespace()) {
+            self.i += 1;
+        }
+    }
+
+    fn expect_multiple<M>(&mut self, matcher: M) -> Option<usize>
+    where
+        M: Fn(u8) -> bool,
+    {
+        self.skip_escape_code();
+        let iorig = self.i;
+        while self.looking_at(&matcher) {
+            self.i += 1;
+        }
+        if self.i == iorig {
+            None
+        } else {
+            Some(self.i - iorig)
+        }
+    }
+
+    fn expect(&mut self, target: u8) -> Option<()> {
+        if self.looking_at(|x| x == target) {
+            self.i += 1;
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn parse_usize(&mut self) -> Option<usize> {
+        let mut res = 0usize;
+        let mut any = false;
+        while let Some(digit) = self.read_digit() {
+            any = true;
+            res = res.checked_mul(10)?;
+            res = res.checked_add(digit)?;
+        }
+        if any {
+            Some(res)
+        } else {
+            None
+        }
+    }
+
+    fn parse_pair(&mut self) -> Option<(usize, usize)> {
+        let p0 = self.parse_usize()?;
+        if self.expect(b',').is_none() {
+            return Some((0, p0));
+        }
+        let p1 = self.parse_usize()?;
+        Some((p0, p1))
+    }
+
+    fn parse_line_number(&mut self) -> Option<HunkHeader> {
+        self.skip_whitespaces();
+        self.expect_multiple(|x| x == b'@')?;
+        self.expect_multiple(|x| x.is_ascii_whitespace())?;
+        self.expect(b'-')?;
+        let minus_range = self.parse_pair()?;
+        self.expect_multiple(|x| x.is_ascii_whitespace())?;
+        self.expect(b'+')?;
+        let plus_range = self.parse_pair()?;
+        self.expect_multiple(|x| x.is_ascii_whitespace())?;
+        self.expect_multiple(|x| x == b'@')?;
+        Some(HunkHeader {
+            minus_range,
+            plus_range,
+        })
+    }
+}
+
+fn parse_line_number(buf: &[u8]) -> Option<HunkHeader> {
+    LineNumberParser::new(&buf).parse_line_number()
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,7 @@ fn shared_spans(added_tokens: &Tokenization, diff_buffer: &Vec<Snake>) -> Vec<Ha
 }
 
 const MAX_MARGIN: usize = 41;
-const MARGIN_SEP: char = ':';
+const MARGIN_SEP: char = ' ';
 
 impl<'a> HunkBuffer<'a> {
     fn new(config: &'a AppConfig) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,6 @@ fn shared_spans(added_tokens: &Tokenization, diff_buffer: &Vec<Snake>) -> Vec<Ha
 }
 
 const MAX_MARGIN: usize = 41;
-const MARGIN_SEP: char = ' ';
 
 impl<'a> HunkBuffer<'a> {
     fn new(config: &'a AppConfig) -> Self {
@@ -387,14 +386,14 @@ impl<'a> HunkBuffer<'a> {
                         let mut margin_buf = &mut margin[..];
                         if is_plus {
                             if current_line_minus != 0 {
-                                write!(margin_buf, "{:w$}{}", ' ', MARGIN_SEP, w = half_margin)?;
+                                write!(margin_buf, "{:w$} ", ' ', w = half_margin)?;
                             }
                             write!(margin_buf, "{:w$}", current_line_plus, w = half_margin)?;
                             current_line_plus += 1;
                         } else {
                             write!(margin_buf, "{:w$}", current_line_minus, w = half_margin)?;
                             if current_line_plus != 0 {
-                                write!(margin_buf, "{}{:w$}", MARGIN_SEP, ' ', w = half_margin)?;
+                                write!(margin_buf, " {:w$}", ' ', w = half_margin)?;
                             }
                             current_line_minus += 1;
                         };
@@ -417,8 +416,7 @@ impl<'a> HunkBuffer<'a> {
                         } else {
                             write!(out, "{:w$}", ' ', w = half_margin)?;
                         }
-                        write!(out, "{}", MARGIN_SEP)?;
-                        write!(out, "{:w$}", current_line_plus, w = half_margin)?;
+                        write!(out, " {:w$}", current_line_plus, w = half_margin)?;
                     }
                     current_line_minus += 1;
                     current_line_plus += 1;

--- a/src/test.rs
+++ b/src/test.rs
@@ -77,12 +77,13 @@ fn test_width() {
     test(9999999999);
     test(10000000000);
     test(14284238234);
-    assert_eq!("123:456".len(), HunkHeader::new(123, 5, 456, 9).width());
-    assert_eq!("1122:456".len(), HunkHeader::new(123, 999, 456, 9).width());
-    assert_eq!(":456".len(), HunkHeader::new(0, 0, 456, 9).width());
-
     for i in 0..64 {
         test(1 << i);
     }
     test(usize::max_value());
+
+    assert_eq!("123:456".len(), HunkHeader::new(123, 5, 456, 9).width());
+    assert_eq!("1122: 456".len(), HunkHeader::new(123, 999, 456, 9).width());
+    assert_eq!("   :456".len(), HunkHeader::new(0, 0, 456, 9).width());
+    assert_eq!(MAX_MARGIN, 2 * width1(usize::max_value()) + 1);
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -42,9 +42,9 @@ fn parse_line_number_test() {
         assert_eq!(None, parse_line_number(input));
     };
     test_ok(133, 6, 133, 8, b"@@ -133,6 +133,8 @@");
-    test_ok(0, 0, 0, 1, b"@@ -0,0 +1 @@");
-    test_ok(0, 0, 0, 1, b"  @@ -0,0 +1 @@");
-    test_ok(0, 0, 0, 1, b"@@   -0,0 +1 @@");
+    test_ok(0, 0, 1, 1, b"@@ -0,0 +1 @@");
+    test_ok(0, 0, 1, 1, b"  @@ -0,0 +1 @@");
+    test_ok(0, 0, 1, 1, b"@@   -0,0 +1 @@");
     test_fail(b"@@-0,0 +1 @@");
     test_fail(b"@@ -0,0+1 @@");
     test_fail(b"@@ -0,0 +1@@");
@@ -57,7 +57,7 @@ fn parse_line_number_test() {
     test_fail(b"@@ -0,0 +19999999999999999999 @@");
 
     // with escape code
-    test_ok(0, 0, 0, 1, b"\x1b[42;43m@\x1b[42;43m@\x1b[42;43m \x1b[42;43m-\x1b[42;43m0\x1b[42;43m,\x1b[42;43m0\x1b[42;43m \x1b[42;43m+1 @@");
+    test_ok(0, 0, 1, 1, b"\x1b[42;43m@\x1b[42;43m@\x1b[42;43m \x1b[42;43m-\x1b[42;43m0\x1b[42;43m,\x1b[42;43m0\x1b[42;43m \x1b[42;43m+1 @@");
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -24,3 +24,65 @@ fn skip_token_test() {
     assert_eq!(1, skip_token(b"\x1b"));
     assert_eq!(0, skip_token(b""));
 }
+
+#[test]
+fn parse_line_number_test() {
+    let test_ok = |ofs1, len1, ofs2, len2, input| {
+        eprintln!("test_ok {}...", String::from_utf8_lossy(input));
+        assert_eq!(
+            Some(HunkHeader {
+                minus_range: (ofs1, len1),
+                plus_range: (ofs2, len2),
+            }),
+            parse_line_number(input)
+        );
+    };
+    let test_fail = |input| {
+        eprintln!("test_fail {}...", String::from_utf8_lossy(input));
+        assert_eq!(None, parse_line_number(input));
+    };
+    test_ok(133, 6, 133, 8, b"@@ -133,6 +133,8 @@");
+    test_ok(0, 0, 0, 1, b"@@ -0,0 +1 @@");
+    test_ok(0, 0, 0, 1, b"  @@ -0,0 +1 @@");
+    test_ok(0, 0, 0, 1, b"@@   -0,0 +1 @@");
+    test_fail(b"@@-0,0 +1 @@");
+    test_fail(b"@@ -0,0+1 @@");
+    test_fail(b"@@ -0,0 +1@@");
+    test_fail(b"@@ -0,0 +1 ");
+    test_fail(b"-0,0 +1");
+    test_fail(b"@@ 0,0 +1 @@");
+    test_fail(b"@@ -0,0 1 @@");
+
+    // overflow
+    test_fail(b"@@ -0,0 +19999999999999999999 @@");
+
+    // with escape code
+    test_ok(0, 0, 0, 1, b"\x1b[42;43m@\x1b[42;43m@\x1b[42;43m \x1b[42;43m-\x1b[42;43m0\x1b[42;43m,\x1b[42;43m0\x1b[42;43m \x1b[42;43m+1 @@");
+}
+
+#[test]
+fn test_width() {
+    for (i, x) in WIDTH.iter().enumerate() {
+        if x < &usize::max_value() {
+            assert_eq!(format!("{}", x + 1).len(), i + 1);
+        }
+    }
+    assert_eq!(0, width1(0));
+    fn test(x: usize) {
+        assert_eq!(format!("{}", x).len(), width1(x));
+    }
+    for i in 1..=10000 {
+        test(i);
+    }
+    test(9999999999);
+    test(10000000000);
+    test(14284238234);
+    assert_eq!("123:456".len(), HunkHeader::new(123, 5, 456, 9).width());
+    assert_eq!("1122:456".len(), HunkHeader::new(123, 999, 456, 9).width());
+    assert_eq!(":456".len(), HunkHeader::new(0, 0, 456, 9).width());
+
+    for i in 0..64 {
+        test(1 << i);
+    }
+    test(usize::max_value());
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -82,8 +82,11 @@ fn test_width() {
     }
     test(usize::max_value());
 
-    assert_eq!("123:456".len(), HunkHeader::new(123, 5, 456, 9).width());
-    assert_eq!("1122: 456".len(), HunkHeader::new(123, 999, 456, 9).width());
-    assert_eq!("   :456".len(), HunkHeader::new(0, 0, 456, 9).width());
+    assert_eq!("123:456".len(), HunkHeader::new((123, 5), (456, 9)).width());
+    assert_eq!(
+        "1122: 456".len(),
+        HunkHeader::new((123, 999), (456, 9)).width()
+    );
+    assert_eq!("   :456".len(), HunkHeader::new((0, 0), (456, 9)).width());
     assert_eq!(MAX_MARGIN, 2 * width1(usize::max_value()) + 1);
 }


### PR DESCRIPTION
Continuing PR #43 (issue #21)

The line numbers are now behind the `--line-numbers` flag.

I also made a few changes to how it's formatted:
- Line numbers are colored for changed lines
- Add minimum margin width of 3. The idea being, 3 digit line numbers will be most common and this will allow different hunks to have aligned code

@mookid I wasn't sure if I should be making a new PR against master or not. Lemme know if I should handle this differently.