### PR TITLE
diffr: fix bad highlighting.

### DIFF
--- a/diffr-lib/src/lib.rs
+++ b/diffr-lib/src/lib.rs
@@ -49,6 +49,21 @@ pub struct Tokenization<'a> {
     token_ids: Vec<TokenId>,
 }
 
+impl Debug for Tokenization<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtErr> {
+        let Self { data, spans, .. } = self;
+        let data_pp = String::from_utf8_lossy(data);
+        let tokens_pp = spans
+            .iter()
+            .map(|sref| String::from_utf8_lossy(&data[sref.0..sref.1]))
+            .collect::<Vec<_>>();
+        f.debug_struct("Tokenization")
+            .field("data", &data_pp)
+            .field("tokens", &tokens_pp)
+            .finish()
+    }
+}
+
 struct TokenizationRange<'a> {
     t: &'a Tokenization<'a>,
     start_index: isize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,6 +453,8 @@ impl<'a> HunkBuffer<'a> {
     fn push_aux(&mut self, line: &[u8], added: bool) {
         let mut ofs = self.lines.len() + 1;
         add_raw_line(&mut self.lines, line);
+        // get back the line sanitized from escape codes:
+        let line = &self.lines.data()[ofs..];
         // XXX: skip leading token and leading spaces
         while ofs < line.len() && line[ofs].is_ascii_whitespace() {
             ofs += 1


### PR DESCRIPTION
This could cause an issue when the added/removed line started with a
common section; in that case the first token was wrongfully
highlighted, because push_aux skipped part of the escape sequence
rather than the '+' / '-' character.

before the PR:
![image](https://user-images.githubusercontent.com/7757342/86840934-962daf00-c0a3-11ea-8bd2-2bccf6f3b5c6.png)


after:
![image](https://user-images.githubusercontent.com/7757342/86840891-88782980-c0a3-11ea-9aeb-83e70f56ce17.png)

Thanks @dandavison for the report.