### PR TITLE
main.rs: improve coloring contrast of white letters

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::io::{self, BufRead, Write};
 use std::iter::Peekable;
 use std::time::SystemTime;
 use termcolor::{
-    Color::{self, Green, Red, White},
+    Color::{self, Green, Red, Rgb},
     ColorChoice, ColorSpec, StandardStream, WriteColor,
 };
 
@@ -31,14 +31,18 @@ pub struct AppConfig {
 
 impl Default for AppConfig {
     fn default() -> Self {
+        // The ANSI white is actually gray on many implementations. The actual white
+        // that seem to work on all implementations is "bright white". `termcolor`
+        // crate has no enum member for it, so we create it with Rgb.
+        let bright_white = Rgb(255, 255, 255);
         AppConfig {
             debug: false,
             html: false,
             line_numbers_style: None,
             added_face: color_spec(Some(Green), None, false),
-            refine_added_face: color_spec(Some(White), Some(Green), true),
+            refine_added_face: color_spec(Some(bright_white), Some(Green), true),
             removed_face: color_spec(Some(Red), None, false),
-            refine_removed_face: color_spec(Some(White), Some(Red), true),
+            refine_removed_face: color_spec(Some(bright_white), Some(Red), true),
         }
     }
 }


### PR DESCRIPTION
The ANSI white is actually gray on many implementations. The actual white that seem to work on all implementations is "bright white". `termcolor` crate has no enum member for it, so we create it with Rgb().

Note that the crate has no support for Rgb() or Ansi256() functions while used in Windows console. Documentation says:

> If they are used on Windows, then they are silently ignored and no
> colors will be emitted

This should more or less work for Windows, because before commit

    7ae151697 "main.rs: use White as a foreground for Red and Green"

…we were not setting the color foreground at all, so in that case behavior is back to the old one. The discussion on the issue #31 being fixed by 7ae151697 mentions that the default White behaves same way there as it did without color being set. Thus, the behavior before and after the current commit should be the same on Windows.

Fixes: https://github.com/mookid/diffr/issues/72