### PR TITLE
Cleanups and fixes to command parsing

### DIFF
--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -307,9 +307,13 @@ fn color(config: &mut AppConfig, args: &mut Peekable<impl Iterator<Item = String
 
 fn line_numbers(config: &mut AppConfig, args: &mut Peekable<impl Iterator<Item = String>>) -> bool {
     let spec = if let Some(spec) = args.peek() {
-        let parse_result = parse_line_number_style(config, Some(&*spec));
-        args.next();
-        parse_result
+        if spec.starts_with("-") { // next option
+            parse_line_number_style(config, None)
+        } else {
+            let parse_result = parse_line_number_style(config, Some(&*spec));
+            args.next();
+            parse_result
+        }
     } else {
         parse_line_number_style(config, None)
     };

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -296,18 +296,20 @@ fn die_error<TRes>(result: Result<TRes, ArgParsingError>) -> bool {
 }
 
 fn color(config: &mut AppConfig, args: &mut Peekable<impl Iterator<Item = String>>) -> bool {
-    let arg = args.next().unwrap();
-    if let Some(spec) = args.next() {
-        die_error(parse_color_arg(&spec, config))
+    if let Some(spec) = args.peek() {
+        let parse_result = parse_color_arg(&spec, config);
+        args.next();
+        die_error(parse_result)
     } else {
-        missing_arg(arg)
+        missing_arg(FLAG_COLOR)
     }
 }
 
 fn line_numbers(config: &mut AppConfig, args: &mut Peekable<impl Iterator<Item = String>>) -> bool {
-    args.next();
-    let spec = if let Some(spec) = args.next() {
-        parse_line_number_style(config, Some(&*spec))
+    let spec = if let Some(spec) = args.peek() {
+        let parse_result = parse_line_number_style(config, Some(&*spec));
+        args.next();
+        parse_result
     } else {
         parse_line_number_style(config, None)
     };
@@ -316,13 +318,11 @@ fn line_numbers(config: &mut AppConfig, args: &mut Peekable<impl Iterator<Item =
 
 fn html(config: &mut AppConfig, args: &mut Peekable<impl Iterator<Item = String>>) -> bool {
     config.html = true;
-    args.next();
     true
 }
 
 fn debug(config: &mut AppConfig, args: &mut Peekable<impl Iterator<Item = String>>) -> bool {
     config.debug = true;
-    args.next();
     true
 }
 
@@ -335,7 +335,7 @@ fn parse_options(
     config: &mut AppConfig,
     args: &mut Peekable<impl Iterator<Item = String>>,
 ) -> bool {
-    if let Some(arg) = args.peek() {
+    if let Some(arg) = args.next() {
         match &arg[..] {
             // generic flags
             "-h" | "--help" => help(&arg[..] == "--help"),

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -306,11 +306,12 @@ fn color(config: &mut AppConfig, args: &mut Peekable<impl Iterator<Item = String
 }
 
 fn line_numbers(config: &mut AppConfig, args: &mut Peekable<impl Iterator<Item = String>>) -> bool {
-    let spec = if let Some(spec) = args.peek() {
+    let maybe_line_number_style = args.peek();
+    let spec = if let Some(spec) = maybe_line_number_style {
         if spec.starts_with("-") { // next option
             parse_line_number_style(config, None)
         } else {
-            let parse_result = parse_line_number_style(config, Some(&*spec));
+            let parse_result = parse_line_number_style(config, maybe_line_number_style.map(|s| &s[..]));
             args.next();
             parse_result
         }

--- a/src/tests_cli.rs
+++ b/src/tests_cli.rs
@@ -233,6 +233,12 @@ fn line_numbers_style() {
         err: Empty,
         is_success: true,
     });
+    test_cli(ProcessTest {
+        args: &["--line-numbers", "--line-numbers"],
+        out: Empty,
+        err: Empty,
+        is_success: true,
+    });
 
     // fail
     test_cli(ProcessTest {


### PR DESCRIPTION
Refactoring aside, this fixes the problem when `--color-numbers` was followed by another option, such as for example `diffr --line-numbers --help`. Such combination of parameters would cause an error before this PR.