### PR TITLE
diff_sequences_kernel_bidirectional: remove step_by()

### DIFF
--- a/src/diffr_lib/mod.rs
+++ b/src/diffr_lib/mod.rs
@@ -438,7 +438,8 @@ fn diff_sequences_kernel_bidirectional(
     assert!(d < ctx_fwd.max);
     assert!(d < ctx_bwd.max);
     let d = to_isize(d);
-    for k in (-d..=d).step_by(2) {
+    let mut k = -d;
+    while k <= d {
         let mut x = if k == -d || k != d && ctx_fwd.v(k - 1) < ctx_fwd.v(k + 1) {
             ctx_fwd.v(k + 1)
         } else {
@@ -454,8 +455,11 @@ fn diff_sequences_kernel_bidirectional(
             return Some((Snake::default().from(x0, y0).len(x - x0), 2 * d - 1));
         }
         *ctx_fwd.v_mut(k) = x;
+
+        k += 2;
     }
-    for k in (-d..=d).step_by(2) {
+    let mut k = -d;
+    while k <= d {
         let mut x = if k == -d || k != d && ctx_bwd.v(k + 1) < ctx_bwd.v(k - 1) {
             ctx_bwd.v(k + 1)
         } else {
@@ -471,6 +475,8 @@ fn diff_sequences_kernel_bidirectional(
             return Some((Snake::default().from(x, y).len(x1 - x), 2 * d));
         }
         *ctx_bwd.v_mut(k) = x - 1;
+
+        k += 2;
     }
     None
 }

--- a/src/diffr_lib/mod.rs
+++ b/src/diffr_lib/mod.rs
@@ -615,11 +615,19 @@ fn diff_sequences_bidirectional_snake(input: &DiffInput, v: &mut Vec<isize>) -> 
 }
 
 fn to_isize(input: usize) -> isize {
-    isize::try_from(input).unwrap()
+    if cfg!(debug_assertions) {
+        isize::try_from(input).unwrap()
+    } else {
+        input as _
+    }
 }
 
 fn to_usize(input: isize) -> usize {
-    usize::try_from(input).unwrap()
+    if cfg!(debug_assertions) {
+        usize::try_from(input).unwrap()
+    } else {
+        input as _
+    }
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]


### PR DESCRIPTION
Profiling reveals that using `step_by()` surprisingly has a performance impact:
![image](https://github.com/mookid/diffr/assets/7757342/06113c97-3d95-4909-8589-eaf63d046198)
That's counter intuitive, but this might be due to https://doc.rust-lang.org/src/core/iter/adapters/step_by.rs.html being a complicated way of doing something that we really want to be simple.

Falling back to the simplest possible code, we get the following profile:
![image](https://github.com/mookid/diffr/assets/7757342/228f0c0a-d08f-4ff3-940d-23ce8df2af85)
which does not have the perf bug.

comparison of runtimes:
- before: 
real	0m20.214s
user	0m19.246s
sys	0m0.666s

- after:
real	0m15.429s
user	0m14.782s
sys	0m0.611s
