### PR TITLE
Stop diffing when the diff input is too large.

### DIFF
--- a/src/diffr_lib/tests_lib.rs
+++ b/src/diffr_lib/tests_lib.rs
@@ -95,8 +95,8 @@ fn diff_sequences_test_aux(
     let m = TokenMap::new(&mut [(toks_a.iter(), &seq_a), (toks_b.iter(), &seq_b)]);
     let tok_a = Tokenization::new(seq_a, &toks_a, &m);
     let tok_b = Tokenization::new(seq_b, &toks_b, &m);
-    let input = DiffInput::new(&tok_b, &tok_a);
-    let input_r = DiffInput::new(&tok_a, &tok_b);
+    let input = DiffInput::new(&tok_b, &tok_a, 123);
+    let input_r = DiffInput::new(&tok_a, &tok_b, 123);
 
     let mut v = vec![];
     let result = diff_sequences_simple_forward(&input, &mut v);
@@ -383,7 +383,7 @@ fn find_splitting_point_test() {
         let m = TokenMap::new(&mut [(toks_a.iter(), &seq_a), (toks_b.iter(), &seq_b)]);
         let tok_a = Tokenization::new(seq_a, &toks_a, &m);
         let tok_b = Tokenization::new(seq_b, &toks_b, &m);
-        let input = DiffInput::new(&tok_b, &tok_a);
+        let input = DiffInput::new(&tok_b, &tok_a, 123);
 
         assert_eq!(expected, find_splitting_point(&input).sp);
         for i in 0..expected {
@@ -470,7 +470,7 @@ fn test_lcs_random() {
         let m = TokenMap::new(&mut [(toks_a.iter(), &seq_a), (toks_b.iter(), &seq_b)]);
         let tok_a = Tokenization::new(seq_a, &toks_a, &m);
         let tok_b = Tokenization::new(seq_b, &toks_b, &m);
-        let input = DiffInput::new(&tok_a, &tok_b);
+        let input = DiffInput::new(&tok_a, &tok_b, 123);
         let mut v = vec![];
         let mut dst = vec![];
         diff(&input, &mut v, &mut dst);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ pub struct AppConfig {
     refine_added_face: ColorSpec,
     removed_face: ColorSpec,
     refine_removed_face: ColorSpec,
+    large_diff_threshold: usize,
 }
 
 impl Default for AppConfig {
@@ -41,6 +42,7 @@ impl Default for AppConfig {
             refine_added_face: color_spec(Some(bright_white), Some(Green), true),
             removed_face: color_spec(Some(Red), None, false),
             refine_removed_face: color_spec(Some(bright_white), Some(Red), true),
+            large_diff_threshold: 1000,
         }
     }
 }
@@ -416,7 +418,7 @@ impl HunkBuffer {
         let m = TokenMap::new(&mut [(removed_tokens.iter(), data), (added_tokens.iter(), data)]);
         let removed = Tokenization::new(data, removed_tokens, &m);
         let added = Tokenization::new(data, added_tokens, &m);
-        let tokens = DiffInput::new(&added, &removed);
+        let tokens = DiffInput::new(&added, &removed, config.large_diff_threshold);
         let start = now(stats.do_timings());
         diffr_lib::diff(&tokens, v, diff_buffer);
         // TODO output the lcs directly out of `diff` instead

--- a/src/tests_cli.rs
+++ b/src/tests_cli.rs
@@ -203,6 +203,37 @@ fn color_ok_multiple() {
 }
 
 #[test]
+fn threshold() {
+    // ok
+    test_cli(ProcessTest {
+        args: &["--large-diff-threshold", "123"],
+        out: Empty,
+        err: Empty,
+        is_success: true,
+    });
+
+    // fail
+    test_cli(ProcessTest {
+        args: &["--large-diff-threshold"],
+        out: Empty,
+        err: Exactly("option requires an argument: '--large-diff-threshold'"),
+        is_success: false,
+    });
+    test_cli(ProcessTest {
+        args: &["--large-diff-threshold", "a"],
+        out: Empty,
+        err: Exactly("invalid threshold value: invalid digit found in string"),
+        is_success: false,
+    });
+    test_cli(ProcessTest {
+        args: &["--large-diff-threshold", "-1"],
+        out: Empty,
+        err: Exactly("invalid threshold value: invalid digit found in string"),
+        is_success: false,
+    });
+}
+
+#[test]
 fn line_numbers_style() {
     // TODO  check config?
 


### PR DESCRIPTION
Adds a new flag `--large-diff-threshold`. When the diff input is larger than this value, the diff is hard to read in any case (even with the help of diffr). In that case, do less work and give up immediately on the diff computation; the diff is then displayed as "all removed, then all added" (every line starting with either '-' or '+' is highlighted).

The new behaviour can be turned off by passing 0 to `--large-diff-threshold`.

This is one of the issues of #14