### PR TITLE
feat: Improve UTF-8 support by keeping graphemes together when tokenizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,11 +3,34 @@
 version = 3
 
 [[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "diffr"
 version = "0.1.5"
 dependencies = [
+ "bstr",
  "termcolor",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ readme = "README.md"
 debug = true
 
 [dependencies]
+bstr = { version = "1.9.1", default-features = false, features = ["unicode"] }
 termcolor = "1.1"

--- a/src/diffr_lib/tests_lib.rs
+++ b/src/diffr_lib/tests_lib.rs
@@ -369,10 +369,12 @@ fn tokenize_test() {
     test(&["abcd", " ", "defg"], b"abcd defg");
     test(&["abcd", "    ", "defg"], b"abcd    defg");
     test(&["abcd", "\t    ", "defg"], b"abcd\t    defg");
+    test(&["ab_cd", " ", "de", "-", "fg"], b"ab_cd de-fg");
     test(
         &["*", "(", "abcd", ")", " ", "#", "[", "efgh", "]"],
         b"*(abcd) #[efgh]",
     );
+    test(&["кирилица", " ", "🧑🏼‍🌾"], "кирилица 🧑🏼‍🌾".as_bytes()); // (cyrilic and a farmer emoji)
 }
 
 #[test]


### PR DESCRIPTION
This uses [`bstr`'s `grapheme_indices`](https://docs.rs/bstr/latest/bstr/trait.ByteSlice.html#method.grapheme_indices) method to break the input text into graphemes, and then classifies them as words/spaces/other similarly as before.

Some screenshots (Konsole):

| Test | Before | After |
| --- | --- | --- |
| UTF-8: Cyrillic :sparkles:, Emojis :sparkles:, Combining characters :sparkles: | ![image](https://github.com/mookid/diffr/assets/5276727/9c3aaa04-a592-4a40-85c5-c56a658edae1) | ![image](https://github.com/mookid/diffr/assets/5276727/a2b9ab28-e74d-46be-a0d8-64543abc4114) ~~(ignore spurious tab on 4)~~ | 
| Windows-1251 :sweat_smile:<br>(diff \| diffr \| iconv) |![image](https://github.com/mookid/diffr/assets/5276727/6f7e697f-5d05-4c52-90e2-1c6747c83fd4) | ![image](https://github.com/mookid/diffr/assets/5276727/09cf84a8-4731-4cfd-8d60-50f662ed7c77) |

